### PR TITLE
Features/add list all files method

### DIFF
--- a/lib/dropbox/client.rb
+++ b/lib/dropbox/client.rb
@@ -122,17 +122,12 @@ module Dropbox
       return FileMetadata.new(resp), body
     end
 
-    def _list_folder(path, opts = nil)
-      args = { path: path }.merge(opts || {})
-      request('/files/list_folder', args)
-    end
-
     # Get the contents of a folder.
     #
     # @param [String] path
     # @return [Array<Dropbox::Metadata>]
     def list_folder(path)
-      resp = _list_folder(path)
+      resp = request('/files/list_folder', path: path)
       resp['entries'].map { |e| parse_tagged_response(e) }
     end
 
@@ -141,7 +136,7 @@ module Dropbox
     # @param [String] path
     # @return [Array<Dropbox::Metadata>]
     def list_all_files(path)
-      resp = _list_folder(path, recursive: true)
+      resp = request('/files/list_folder', path: path, recursive: true)
       has_more = resp['has_more']
       cursor = resp['cursor']
       entries = resp['entries']

--- a/test/stubs/recursive_folder_contents.json
+++ b/test/stubs/recursive_folder_contents.json
@@ -1,0 +1,33 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "entries": [
+        {
+            ".tag": "folder",
+            "name": "math",
+            "id": "id:a4ayc_80_OEAAAAAAAAAXz",
+            "path_lower": "/homework/math",
+            "path_display": "/Homework/math",
+            "sharing_info": {
+                "read_only": false,
+                "parent_shared_folder_id": "84528192421",
+                "traverse_only": false,
+                "no_access": false
+            },
+            "property_groups": [
+                {
+                    "template_id": "ptid:1a5n2i6d3OYEAAAAAAAAAYa",
+                    "fields": [
+                        {
+                            "name": "Security Policy",
+                            "value": "Confidential"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "cursor": "PART1_CURSOR",
+    "has_more": true
+}

--- a/test/stubs/recursive_folder_contents_part_2.json
+++ b/test/stubs/recursive_folder_contents_part_2.json
@@ -1,0 +1,37 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "entries": [
+        {
+            ".tag": "file",
+            "name": "Prime_Numbers.txt",
+            "id": "id:a4ayc_80_OEAAAAAAAAAXw",
+            "client_modified": "2015-05-12T15:50:38Z",
+            "server_modified": "2015-05-12T15:50:38Z",
+            "rev": "a1c10ce0dd78",
+            "size": 7212,
+            "path_lower": "/homework/math/prime_numbers.txt",
+            "path_display": "/Homework/math/Prime_Numbers.txt",
+            "sharing_info": {
+                "read_only": true,
+                "parent_shared_folder_id": "84528192421",
+                "modified_by": "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc"
+            },
+            "property_groups": [
+                {
+                    "template_id": "ptid:1a5n2i6d3OYEAAAAAAAAAYa",
+                    "fields": [
+                        {
+                            "name": "Security Policy",
+                            "value": "Confidential"
+                        }
+                    ]
+                }
+            ],
+            "has_explicit_shared_members": false
+        }
+    ],
+    "cursor": "PART2_CURSOR",
+    "has_more": true
+}

--- a/test/stubs/recursive_folder_contents_part_3.json
+++ b/test/stubs/recursive_folder_contents_part_3.json
@@ -1,0 +1,37 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "entries": [
+        {
+            ".tag": "file",
+            "name": "Irrational_Numbers.txt",
+            "id": "id:a4ayc_80_OEAAAAAAAAAXZ",
+            "client_modified": "2015-05-12T15:50:38Z",
+            "server_modified": "2015-05-12T15:50:38Z",
+            "rev": "a1c10ce0dd79",
+            "size": 7200,
+            "path_lower": "/homework/math/irrational_numbers.txt",
+            "path_display": "/Homework/math/Irrational_Numbers.txt",
+            "sharing_info": {
+                "read_only": true,
+                "parent_shared_folder_id": "84528192421",
+                "modified_by": "dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngd"
+            },
+            "property_groups": [
+                {
+                    "template_id": "ptid:1a5n2i6d3OYEAAAAAAAAAYa",
+                    "fields": [
+                        {
+                            "name": "Security Policy",
+                            "value": "Confidential"
+                        }
+                    ]
+                }
+            ],
+            "has_explicit_shared_members": false
+        }
+    ],
+    "cursor": "ZZZZZ_EHj3x7PMkVuFIhwKYXEpwpLwyxp9vMKomUhllil9q7eWiAB",
+    "has_more": false
+}

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -161,6 +161,27 @@ class DropboxFilesTest < Minitest::Test
     assert_equal 'math', entries[1].name
   end
 
+  def test_list_all_files
+    stub_request(:post, url('files/list_folder'))
+      .with(body: { recursive: true, path: '/Homework/math' } )
+      .to_return(stub('recursive_folder_contents'))
+    stub_request(:post, url('files/list_folder/continue'))
+      .with(body: { cursor: "PART1_CURSOR" })
+      .to_return(stub('recursive_folder_contents_part_2'))
+    stub_request(:post, url('files/list_folder/continue'))
+      .with(body: { cursor: "PART2_CURSOR" })
+      .to_return(stub('recursive_folder_contents_part_3'))
+
+    entries = @client.list_all_files('/Homework/math')
+
+    assert_equal 2, entries.length
+    assert entries[0].is_a?(Dropbox::FileMetadata)
+    assert_equal 'Prime_Numbers.txt', entries[0].name
+    assert_equal 7212, entries[0].size
+    assert_equal 'Irrational_Numbers.txt', entries[1].name
+    assert_equal 7200, entries[1].size
+  end
+
   def test_list_folder_empty
     stub_request(:post, url('files/list_folder')).to_return(stub('empty_folder_contents'))
     entries = @client.list_folder('/empty_folder')


### PR DESCRIPTION
Add a `list_all_files` method to `Client`
* uses the `files/list_folder/continue` endpoint with a cursor
* replaces `/delta` from v1 - https://www.dropbox.com/developers/reference/migration-guide
