### PR TITLE
Rely on Exception#message rather than overloading with attr_reader

### DIFF
--- a/lib/dropbox/errors.rb
+++ b/lib/dropbox/errors.rb
@@ -3,8 +3,6 @@ require 'json'
 module Dropbox
   # Thrown when Dropbox::Client encounters an error unrelated to the API.
   class ClientError < StandardError
-    attr_reader :message
-
     def self.invalid_access_token
       self.new("Invalid access token")
     end
@@ -24,8 +22,6 @@ module Dropbox
 
   # Thrown when the API returns an error response.
   class ApiError < StandardError
-    attr_reader :message
-
     def initialize(response)
       if response.content_type.mime_type == 'application/json'
         @message = JSON.parse(response)['error_summary']


### PR DESCRIPTION
Ruby implements a method, Exception#message, which returns the result of calling #to_s on the exception object: https://ruby-doc.org/core-2.2.0/Exception.html#method-i-message

In the ApiError class, the constructor in some cases sets @message to be an HTTP::Response object. Removing the message attr_reader allows Exception#message to be called instead, which in turn calls #to_s. This change ensures that #message always returns a string, rather than sometimes unexpectedly returning an HTTP::Response object.