### PR TITLE
Added content_hash to FileMetadata and options to list_folder request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# for old fashioned emacs users like me
+*~

--- a/lib/dropbox/client.rb
+++ b/lib/dropbox/client.rb
@@ -125,9 +125,17 @@ module Dropbox
     # Get the contents of a folder.
     #
     # @param [String] path
+    # @param [Hash] options 
+    # @option (see #list_folder)
     # @return [Array<Dropbox::Metadata>]
-    def list_folder(path)
-      resp = request('/files/list_folder', path: path)
+    def list_folder(path, options={})
+      options[:path] = path
+      options[:recursive] ||= false
+      options[:include_deleted] ||= false
+      options[:include_media_info] ||= false
+      options[:include_has_explicit_shared_members] ||= false
+      options[:include_mounted_folders] ||= true
+      resp = request('/files/list_folder', options)
       resp['entries'].map { |e| parse_tagged_response(e) }
     end
 

--- a/lib/dropbox/metadata.rb
+++ b/lib/dropbox/metadata.rb
@@ -14,7 +14,8 @@ module Dropbox
 
   # Contains the metadata (but not contents) of a file.
   class FileMetadata < Metadata
-    attr_reader :id, :client_modified, :server_modified, :rev, :size
+    attr_reader :id, :client_modified, :server_modified, :rev,
+                :size, :content_hash
 
     def initialize(attrs={})
       @id = attrs.delete('id')
@@ -24,6 +25,7 @@ module Dropbox
       @server_modified = Time.parse(attrs.delete('server_modified'))
       @rev = attrs.delete('rev')
       @size = attrs.delete('size')
+      @content_hash = attrs.delete('content_hash')
       super(attrs)
     end
 


### PR DESCRIPTION
Hi,

A couple of additions for your consideration, please:

- Content_hash information allows us to check locally if the file has been changed since the previous upload (using the DropboxContentHasher gem, for example).  This PR add this field to FileMetadata.

- The list_folder API call has some useful options, e.g. recursing, listing deleted files, etc., so these options have been added into this method.

- Optionally, I've cheekily included emacs save files to the .gitignore file. :-)

Thanks,

Jason